### PR TITLE
please include doc in 1.10.4 release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.creole
 include versioneer.py
 include pg8000/_version.py
+include LICENSE
 include doc/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.creole
 include versioneer.py
 include pg8000/_version.py
+include doc/*


### PR DESCRIPTION
Hello

In the 1.10.3 release available in pypi the doc diretory is include in the tarball, I have noticed than in the 1.10.4 release the doc it is not include, in the RPM packaging I make the html documentation and release as a doc subpackage, can you please include the doc directori in the release?

http://arm.koji.fedoraproject.org/koji/buildinfo?buildID=347525