### PR TITLE
Remove six references.

### DIFF
--- a/pg8000/pg_scram.py
+++ b/pg8000/pg_scram.py
@@ -4,7 +4,6 @@ from uuid import uuid4
 from passlib.utils import saslprep
 from base64 import b64encode, b64decode
 import hashlib
-from six import b
 
 
 # https://tools.ietf.org/html/rfc5802
@@ -91,7 +90,7 @@ def _client_final_message(
     client_key = _hmac(salted_password, "Client Key")
     stored_key = _h(client_key)
 
-    message = ['c=' + _b64enc(b('n,,')), 'r=' + nonce]
+    message = ['c=' + _b64enc(b'n,,'), 'r=' + nonce]
 
     auth_message = ','.join(
         (client_first_message_bare, server_first_message, ','.join(message)))

--- a/tests/dbapi20.py
+++ b/tests/dbapi20.py
@@ -2,7 +2,6 @@
 import unittest
 import time
 import warnings
-from six import b
 ''' Python DB API 2.0 driver compliance unit test suite.
 
     This software is Public Domain and may be used without restrictions.
@@ -279,7 +278,7 @@ class DatabaseAPI20Test(unittest.TestCase):
                 len(cur.description[0]), 7,
                 'cursor.description[x] tuples must have 7 elements')
             self.assertEqual(
-                cur.description[0][0].lower(), b('name'),
+                cur.description[0][0].lower(), b'name',
                 'cursor.description[x][0] must return column name')
             self.assertEqual(
                 cur.description[0][1], self.driver.STRING,
@@ -802,8 +801,8 @@ class DatabaseAPI20Test(unittest.TestCase):
         # self.assertEqual(str(t1),str(t2))
 
     def test_Binary(self):
-        self.driver.Binary(b('Something'))
-        self.driver.Binary(b(''))
+        self.driver.Binary(b'Something')
+        self.driver.Binary(b'')
 
     def test_STRING(self):
         self.assertEqual(

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,7 +1,6 @@
 import unittest
 import pg8000
 from connection_settings import db_connect
-from six import PY2, u
 import sys
 from distutils.version import LooseVersion
 import socket
@@ -88,12 +87,8 @@ class Tests(unittest.TestCase):
         data["database"] = "pg8000_md5"
 
         # Should only raise an exception saying db doesn't exist
-        if PY2:
-            self.assertRaises(
-                pg8000.ProgrammingError, pg8000.connect, **data)
-        else:
-            self.assertRaisesRegex(
-                pg8000.ProgrammingError, '3D000', pg8000.connect, **data)
+        self.assertRaisesRegex(
+            pg8000.ProgrammingError, '3D000', pg8000.connect, **data)
 
     # This requires a line in pg_hba.conf that requires gss for the database
     # pg8000_gss
@@ -103,13 +98,10 @@ class Tests(unittest.TestCase):
         data["database"] = "pg8000_gss"
 
         # Should raise an exception saying gss isn't supported
-        if PY2:
-            self.assertRaises(pg8000.InterfaceError, pg8000.connect, **data)
-        else:
-            self.assertRaisesRegex(
-                pg8000.InterfaceError,
-                "Authentication method 7 not supported by pg8000.",
-                pg8000.connect, **data)
+        self.assertRaisesRegex(
+            pg8000.InterfaceError,
+            "Authentication method 7 not supported by pg8000.",
+            pg8000.connect, **data)
 
     @trust_all_certificates
     def testSsl(self):
@@ -126,43 +118,30 @@ class Tests(unittest.TestCase):
         data["database"] = "pg8000_password"
 
         # Should only raise an exception saying db doesn't exist
-        if PY2:
-            self.assertRaises(
-                pg8000.ProgrammingError, pg8000.connect, **data)
-        else:
-            self.assertRaisesRegex(
-                pg8000.ProgrammingError, '3D000', pg8000.connect, **data)
+        self.assertRaisesRegex(
+            pg8000.ProgrammingError, '3D000', pg8000.connect, **data)
 
     def testUnicodeDatabaseName(self):
         data = db_connect.copy()
         data["database"] = "pg8000_sn\uFF6Fw"
 
         # Should only raise an exception saying db doesn't exist
-        if PY2:
-            self.assertRaises(
-                pg8000.ProgrammingError, pg8000.connect, **data)
-        else:
-            self.assertRaisesRegex(
-                pg8000.ProgrammingError, '3D000', pg8000.connect, **data)
+        self.assertRaisesRegex(
+            pg8000.ProgrammingError, '3D000', pg8000.connect, **data)
 
     def testBytesDatabaseName(self):
         data = db_connect.copy()
 
         # Should only raise an exception saying db doesn't exist
-        if PY2:
-            data["database"] = "pg8000_sn\uFF6Fw"
-            self.assertRaises(
-                pg8000.ProgrammingError, pg8000.connect, **data)
-        else:
-            data["database"] = bytes("pg8000_sn\uFF6Fw", 'utf8')
-            self.assertRaisesRegex(
-                pg8000.ProgrammingError, '3D000', pg8000.connect, **data)
+        data["database"] = bytes("pg8000_sn\uFF6Fw", 'utf8')
+        self.assertRaisesRegex(
+            pg8000.ProgrammingError, '3D000', pg8000.connect, **data)
 
     def testBytesPassword(self):
         with pg8000.connect(**db_connect) as db:
             # Create user
             username = 'boltzmann'
-            password = u('cha\uFF6Fs')
+            password = 'cha\uFF6Fs'
             cur = db.cursor()
 
             # Delete user if left over from previous run
@@ -180,12 +159,8 @@ class Tests(unittest.TestCase):
             data['user'] = username
             data['password'] = password.encode('utf8')
             data['database'] = 'pg8000_md5'
-            if PY2:
-                self.assertRaises(
-                    pg8000.ProgrammingError, pg8000.connect, **data)
-            else:
-                self.assertRaisesRegex(
-                    pg8000.ProgrammingError, '3D000', pg8000.connect, **data)
+            self.assertRaisesRegex(
+                pg8000.ProgrammingError, '3D000', pg8000.connect, **data)
 
         with pg8000.connect(**db_connect) as db:
             cur = db.cursor()
@@ -233,12 +208,8 @@ class Tests(unittest.TestCase):
         data["database"] = "pg8000_scram_sha_256"
 
         # Should only raise an exception saying db doesn't exist
-        if PY2:
-            self.assertRaises(
-                pg8000.ProgrammingError, pg8000.connect, **data)
-        else:
-            self.assertRaisesRegex(
-                pg8000.ProgrammingError, '3D000', pg8000.connect, **data)
+        self.assertRaisesRegex(
+            pg8000.ProgrammingError, '3D000', pg8000.connect, **data)
 
 
 if __name__ == "__main__":

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,7 +1,7 @@
 import unittest
 import pg8000
 from connection_settings import db_connect
-from six import b, BytesIO, u, iteritems
+from io import BytesIO
 from sys import exc_info
 
 
@@ -44,7 +44,7 @@ class Tests(unittest.TestCase):
             stream = BytesIO()
             cursor.execute("copy t1 to stdout", stream=stream)
             self.assertEqual(
-                stream.getvalue(), b("1\t1\t1\n2\t2\t2\n3\t3\t3\n"))
+                stream.getvalue(), b"1\t1\t1\n2\t2\t2\n3\t3\t3\n")
             self.assertEqual(cursor.rowcount, 3)
             self.db.commit()
         finally:
@@ -57,7 +57,7 @@ class Tests(unittest.TestCase):
             cursor.execute(
                 "COPY (SELECT 1 as One, 2 as Two) TO STDOUT WITH DELIMITER "
                 "'X' CSV HEADER QUOTE AS 'Y' FORCE QUOTE Two", stream=stream)
-            self.assertEqual(stream.getvalue(), b('oneXtwo\n1XY2Y\n'))
+            self.assertEqual(stream.getvalue(), b'oneXtwo\n1XY2Y\n')
             self.assertEqual(cursor.rowcount, 1)
             self.db.rollback()
         finally:
@@ -66,7 +66,7 @@ class Tests(unittest.TestCase):
     def testCopyFromWithTable(self):
         try:
             cursor = self.db.cursor()
-            stream = BytesIO(b("1\t1\t1\n2\t2\t2\n3\t3\t3\n"))
+            stream = BytesIO(b"1\t1\t1\n2\t2\t2\n3\t3\t3\n")
             cursor.execute("copy t1 from STDIN", stream=stream)
             self.assertEqual(cursor.rowcount, 3)
 
@@ -80,7 +80,7 @@ class Tests(unittest.TestCase):
     def testCopyFromWithQuery(self):
         try:
             cursor = self.db.cursor()
-            stream = BytesIO(b("f1Xf2\n1XY1Y\n"))
+            stream = BytesIO(b"f1Xf2\n1XY1Y\n")
             cursor.execute(
                 "COPY t1 (f1, f2) FROM STDIN WITH DELIMITER 'X' CSV HEADER "
                 "QUOTE AS 'Y' FORCE NOT NULL f1", stream=stream)
@@ -96,22 +96,22 @@ class Tests(unittest.TestCase):
     def testCopyFromWithError(self):
         try:
             cursor = self.db.cursor()
-            stream = BytesIO(b("f1Xf2\n\n1XY1Y\n"))
+            stream = BytesIO(b"f1Xf2\n\n1XY1Y\n")
             cursor.execute(
                 "COPY t1 (f1, f2) FROM STDIN WITH DELIMITER 'X' CSV HEADER "
                 "QUOTE AS 'Y' FORCE NOT NULL f1", stream=stream)
             self.assertTrue(False, "Should have raised an exception")
         except BaseException:
             args_dict = {
-                'S': u('ERROR'),
-                'C': u('22P02'),
-                'M': u('invalid input syntax for integer: ""'),
-                'W': u('COPY t1, line 2, column f1: ""'),
-                'F': u('numutils.c'),
-                'R': u('pg_atoi')
+                'S': 'ERROR',
+                'C': '22P02',
+                'M': 'invalid input syntax for integer: ""',
+                'W': 'COPY t1, line 2, column f1: ""',
+                'F': 'numutils.c',
+                'R': 'pg_atoi'
             }
             args = exc_info()[1].args[0]
-            for k, v in iteritems(args_dict):
+            for k, v in args_dict.items():
                 self.assertEqual(args[k], v)
         finally:
             cursor.close()

--- a/tests/test_dbapi.py
+++ b/tests/test_dbapi.py
@@ -5,7 +5,6 @@ import pg8000
 import datetime
 from connection_settings import db_connect
 from sys import exc_info
-from six import b
 from distutils.version import LooseVersion
 
 
@@ -201,8 +200,8 @@ class Tests(unittest.TestCase):
             self.assertEqual(val, datetime.datetime(2007, 3, 13, 16, 45, 19))
 
     def testBinary(self):
-        v = pg8000.Binary(b("\x00\x01\x02\x03\x02\x01\x00"))
-        self.assertEqual(v, b("\x00\x01\x02\x03\x02\x01\x00"))
+        v = pg8000.Binary(b"\x00\x01\x02\x03\x02\x01\x00")
+        self.assertEqual(v, b"\x00\x01\x02\x03\x02\x01\x00")
         self.assertTrue(isinstance(v, pg8000.BINARY))
 
     def testRowCount(self):


### PR DESCRIPTION
- The 1.13.0 release of pg8000 removed Python 2.7 support and six from it's requirements. This removes usages of six that remained and would cause import errors.

Issues: NA