### PR TITLE
Treating oversized integers as `Decimal` rather than `None`

### DIFF
--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -1690,6 +1690,7 @@ class Connection():
             return self.py_types[23]
         if min_int8 < value < max_int8:
             return self.py_types[20]
+        return self.py_types[Decimal]
 
     def make_params(self, values):
         params = []


### PR DESCRIPTION
Previously, queries would fail with a delightfully cryptic error of

```
TypeError: 'NoneType' object is not subscriptable (key 2)
```

The fix should be either this, or raising an exception telling the user to cast large integers to `Decimal` instead.