### PR TITLE
tests: support unix sockets for PGHOST

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,30 @@
+import os.path
+from os import environ
+
+import pytest
+
+
+@pytest.fixture(scope="class")
+def db_kwargs():
+    db_connect = {
+        'user': 'postgres',
+        'password': 'pw'
+    }
+
+    for kw, var, f in [
+                ('password', 'PGPASSWORD', str),
+                ('port', 'PGPORT', int)
+            ]:
+        try:
+            db_connect[kw] = f(environ[var])
+        except KeyError:
+            pass
+
+    if 'PGHOST' in environ:
+        pg_host = environ['PGHOST']
+        if os.path.isabs(pg_host):
+            db_connect['unix_sock'] = os.path.join(pg_host, '.s.PGSQL.{}'.format(db_connect.get('port', 5432)))
+        else:
+            db_connect['host'] = pg_host
+
+    return db_connect

--- a/test/dbapi/conftest.py
+++ b/test/dbapi/conftest.py
@@ -1,29 +1,8 @@
 import sys
-from os import environ
 
 import pg8000.dbapi
 
 import pytest
-
-
-@pytest.fixture(scope="class")
-def db_kwargs():
-    db_connect = {
-        'user': 'postgres',
-        'password': 'pw'
-    }
-
-    for kw, var, f in [
-                ('host', 'PGHOST', str),
-                ('password', 'PGPASSWORD', str),
-                ('port', 'PGPORT', int)
-            ]:
-        try:
-            db_connect[kw] = f(environ[var])
-        except KeyError:
-            pass
-
-    return db_connect
 
 
 @pytest.fixture

--- a/test/legacy/conftest.py
+++ b/test/legacy/conftest.py
@@ -1,29 +1,8 @@
 import sys
-from os import environ
 
 import pg8000
 
 import pytest
-
-
-@pytest.fixture(scope="class")
-def db_kwargs():
-    db_connect = {
-        'user': 'postgres',
-        'password': 'pw'
-    }
-
-    for kw, var, f in [
-                ('host', 'PGHOST', str),
-                ('password', 'PGPASSWORD', str),
-                ('port', 'PGPORT', int)
-            ]:
-        try:
-            db_connect[kw] = f(environ[var])
-        except KeyError:
-            pass
-
-    return db_connect
 
 
 @pytest.fixture

--- a/test/native/conftest.py
+++ b/test/native/conftest.py
@@ -1,29 +1,8 @@
 import sys
-from os import environ
 
 import pg8000.native
 
 import pytest
-
-
-@pytest.fixture(scope="class")
-def db_kwargs():
-    db_connect = {
-        'user': 'postgres',
-        'password': 'pw'
-    }
-
-    for kw, var, f in [
-                ('host', 'PGHOST', str),
-                ('password', 'PGPASSWORD', str),
-                ('port', 'PGPORT', int)
-            ]:
-        try:
-            db_connect[kw] = f(environ[var])
-        except KeyError:
-            pass
-
-    return db_connect
 
 
 @pytest.fixture


### PR DESCRIPTION
Hi, I'm the maintainer of the [python-pg8000](https://archlinux.org/packages/community/any/python-pg8000/) package at Arch Linux. I [use pifpaf](https://github.com/archlinux/svntogit-community/blob/packages/python-pg8000/trunk/PKGBUILD#L42) to create a transient PostgreSQL daemon for running tests, and pifpaf runs postgres in a temporary dir and [points `$PGHOST` to that dir](https://github.com/jd/pifpaf/blob/3.1.5/pifpaf/drivers/postgresql.py#L51). This patch adds support for connecting to the unix domain socket specified by `$PGHOST` and `$PGPORT` as described by [PostgreSQL documentation](https://www.postgresql.org/docs/13/libpq-connect.html#LIBPQ-CONNECT-HOST).