### PR TITLE
put 'connection is closed' to InterfaceErrors

### DIFF
--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -257,7 +257,7 @@ class CoreConnection():
             try:
                 self._sock.flush()
             except OSError as e:
-                raise InterfaceError("network error on flush") from e
+                raise InterfaceError("network error on flush, connection is closed") from e
 
         self._flush = sock_flush
 
@@ -265,7 +265,7 @@ class CoreConnection():
             try:
                 return self._sock.read(b)
             except OSError as e:
-                raise InterfaceError("network error on read") from e
+                raise InterfaceError("network error on read, connection is closed") from e
 
         self._read = sock_read
 
@@ -273,7 +273,7 @@ class CoreConnection():
             try:
                 self._sock.write(d)
             except OSError as e:
-                raise InterfaceError("network error on write") from e
+                raise InterfaceError("network error on write, connection is closed") from e
 
         self._write = sock_write
         self._backend_key_data = None

--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -917,7 +917,7 @@ class CoreConnection():
             try:
                 code, data_len = ci_unpack(self._read(5))
             except struct.error as e:
-                raise InterfaceError("network error on read") from e
+                raise InterfaceError("network error on read, connection is closed") from e
 
             self.message_types[code](self._read(data_len - 4), context)
 


### PR DESCRIPTION
- As the Python DBAPI provides no standard system for determining the nature of an exception, all SQLAlchemy dialects include a system called is_disconnect() which will examine the contents of an exception object, including the string message and any potential error codes included with it, in order to determine if this exception indicates that the connection is no longer usable.

In the SqlAlchemy repository, I found [pg8000.py](https://github.com/sqlalchemy/sqlalchemy/blob/640cd8a70f8a664b7834c5f74ec322fdea644043/lib/sqlalchemy/dialects/postgresql/pg8000.py). I don't know who provides this code but it includes:

``` Python
    def is_disconnect(self, e, connection, cursor):
        return "connection is closed" in str(e)
```

I guess, we should put this message to errors to invalidate the connection.