### PR TITLE
Fixing the pg8000 since it can't connect to AWS RDS Proxy

### DIFF
--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -713,7 +713,8 @@ class CoreConnection:
             self._write(code)
             self._write(i_pack(len(data) + 4))
             self._write(data)
-            self._write(FLUSH_MSG)
+            if (code != PASSWORD):
+                self._write(FLUSH_MSG)
         except ValueError as e:
             if str(e) == "write to closed file":
                 raise InterfaceError("connection is closed")


### PR DESCRIPTION
why:a pg8000 does not work when AWS RDS proxy is used.
There is stackoverlow about this https://stackoverflow.com/questions/67242059/aws-rds-proxy-error-postgres-rds-proxy-currently-doesn-t-support-command-lin
what: we tested this in our lambda using AWS RDS Proxy and pg8000 and simple solution was chaning two line of code in core.py