### PR TITLE
Declare support for Python 3.9 and 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,8 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: Jython",


### PR DESCRIPTION
Add Trove classifiers so it shows up on PyPI and through the PyPI API.