### PR TITLE
Fix tests

### DIFF
--- a/test/legacy/test_auth.py
+++ b/test/legacy/test_auth.py
@@ -22,6 +22,7 @@ def testGss(db_kwargs):
 def test_ssl(db_kwargs):
     context = ssl.create_default_context()
     context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
     db_kwargs["ssl_context"] = context
     with pg8000.connect(**db_kwargs):
         pass

--- a/test/native/test_auth.py
+++ b/test/native/test_auth.py
@@ -23,6 +23,7 @@ def test_gss(db_kwargs):
 def test_ssl(db_kwargs):
     context = ssl.create_default_context()
     context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
     db_kwargs["ssl_context"] = context
     with pg8000.native.Connection(**db_kwargs):
         pass


### PR DESCRIPTION
Fix the following two test failures during `pyest test`:

<details>
<summary>Test logs</summary>

```
___________________________________ test_ssl ___________________________________

db_kwargs = {'host': '127.0.0.1', 'password': 'pw', 'port': 57053, 'ssl_context': <ssl.SSLContext object at 0x7f7ceea40fc0>, ...}

    def test_ssl(db_kwargs):
        context = ssl.create_default_context()
        context.check_hostname = False
        db_kwargs["ssl_context"] = context
>       with pg8000.connect(**db_kwargs):

test/legacy/test_auth.py:26:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pg8000/__init__.py:117: in connect
    return Connection(
pg8000/legacy.py:442: in __init__
    super().__init__(*args, **kwargs)
pg8000/core.py:255: in __init__
    self._usock = ssl_context.wrap_socket(self._usock, server_hostname=host)
/usr/lib/python3.10/ssl.py:512: in wrap_socket
    return self.sslsocket_class._create(
/usr/lib/python3.10/ssl.py:1070: in _create
    self.do_handshake()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <ssl.SSLSocket [closed] fd=-1, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
block = False

    @_sslcopydoc
    def do_handshake(self, block=False):
        self._check_connected()
        timeout = self.gettimeout()
        try:
            if timeout == 0.0 and block:
                self.settimeout(None)
>           self._sslobj.do_handshake()
E           ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate (_ssl.c:997)

/usr/lib/python3.10/ssl.py:1341: SSLCertVerificationError
___________________________________ test_ssl ___________________________________

db_kwargs = {'host': '127.0.0.1', 'password': 'pw', 'port': 57053, 'ssl_context': <ssl.SSLContext object at 0x7f7ceea411c0>, ...}

    def test_ssl(db_kwargs):
        context = ssl.create_default_context()
        context.check_hostname = False
        db_kwargs["ssl_context"] = context
>       with pg8000.native.Connection(**db_kwargs):

test/native/test_auth.py:27:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pg8000/native.py:179: in __init__
    super().__init__(*args, **kwargs)
pg8000/core.py:255: in __init__
    self._usock = ssl_context.wrap_socket(self._usock, server_hostname=host)
/usr/lib/python3.10/ssl.py:512: in wrap_socket
    return self.sslsocket_class._create(
/usr/lib/python3.10/ssl.py:1070: in _create
    self.do_handshake()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <ssl.SSLSocket [closed] fd=-1, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
block = False

    @_sslcopydoc
    def do_handshake(self, block=False):
        self._check_connected()
        timeout = self.gettimeout()
        try:
            if timeout == 0.0 and block:
                self.settimeout(None)
>           self._sslobj.do_handshake()
E           ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate (_ssl.c:997)

/usr/lib/python3.10/ssl.py:1341: SSLCertVerificationError
```
</details>

I noticed this when upgrading I'm the Arch Linux package [python-pg8000](https://archlinux.org/packages/community/any/python-pg8000/) to 1.26.0. Apparently those failures do not happen in GitHub Actions as they are [ignored](https://github.com/tlocke/pg8000/blob/main/.github/workflows/test.yml#L50).