### PR TITLE
Fixed 'malformed array literal' with texts like \n or \r

### DIFF
--- a/pg8000/converters.py
+++ b/pg8000/converters.py
@@ -594,7 +594,7 @@ def array_string_escape(v):
     if (
         len(val) == 0
         or val == "NULL"
-        or any([c in val for c in ("{", "}", ",", " ", "\\")])
+        or any([c in val for c in ("{", "}", ",", " ", "\\", "\r", "\n")])
     ):
         val = f'"{val}"'
     return val

--- a/test/dbapi/test_typeconversion.py
+++ b/test/dbapi/test_typeconversion.py
@@ -651,6 +651,10 @@ def test_string_array_roundtrip(cursor):
         "",
         "A bunch of random characters:",
         " ~!@#$%^&*()_+`1234567890-=[]\\{}|{;':\",./<>?\t",
+        "\n",
+        "\r",
+        "\t",
+        "\b",
         None,
     ]
     cursor.execute("SELECT cast(%s as varchar[])", (v,))


### PR DESCRIPTION
Closes #115 

Although I've extended the test case to demo the bug, I haven't been able to run the test suite locally. So the test is untested, sorry!