### PR TITLE
Set a default `CURRENCY`

### DIFF
--- a/test/native/test_typeconversion.py
+++ b/test/native/test_typeconversion.py
@@ -519,11 +519,10 @@ def test_float8_array_out(con):
 
 CURRENCIES = {
     "en_GB.UTF-8": "£",
-    "C.UTF-8": "$",
-    "C.UTF8": "$",
 }
 
 # Find the currency string
+CURRENCY = "$"
 for LC in ("LC_CTYPE", "LANG"):
     try:
         LC_VAL = os.environ[LC]


### PR DESCRIPTION
This fixes a `NameError` that occurs on platforms that don't have any of the listed locale values present. (For example, `LANG=en_US.UTF-8` results in a `NameError`.)

Fixes #130