### PR TITLE
Fix typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -593,7 +593,7 @@ pg8000 has a mapping from PostgreSQL types to Python types for when it receives 
 results from the server. The default mapping that comes with pg8000 is designed to work
 well in most cases, but you might want to add or replace the default mapping.
 
-If pg800 recieves PostgreSQL ``interval`` type, which has the ``oid`` 1186, it converts
+If pg8000 receives PostgreSQL ``interval`` type, which has the ``oid`` 1186, it converts
 it into a Python ``datetime.timedelta`` object. But let's say we wanted to create our
 own Python class to be used instead of ``datetime.timedelta``. Then we'd have to
 register an adapter:
@@ -672,7 +672,7 @@ repeatedly. Here's an example:
 >>> # Create the prepared statement
 >>> ps = con.prepare("SELECT cast(:v as varchar)")
 >>>
->>> # Exceute the statement repeatedly
+>>> # Execute the statement repeatedly
 >>> ps.run(v="speedy")
 [['speedy']]
 >>> ps.run(v="rapid")
@@ -1692,7 +1692,7 @@ replication
 
 pg8000.dbapi.Date(year, month, day)
 
-Constuct an object holding a date value.
+Construct an object holding a date value.
 
 This property is part of the `DBAPI 2.0 specification
 <http://www.python.org/dev/peps/pep-0249/>`_.
@@ -1728,7 +1728,7 @@ Returns: ``datetime.datetime``
 pg8000.dbapi.TimeFromTicks(ticks)
 :::::::::::::::::::::::::::::::::
 
-Construct an objet holding a time value from the given ticks value (number of seconds
+Construct an object holding a time value from the given ticks value (number of seconds
 since the epoch).
 
 Returns: ``datetime.time``
@@ -2303,5 +2303,5 @@ Version 1.22.0, 2021-10-13
 
 - Rather than specifying the oids in the ``Parse`` step of the Postgres protocol, pg8000
   now omits them, and so Postgres will use the oids it determines from the query. This
-  makes the pg8000 code simplier and also it should also make the nuances of type
+  makes the pg8000 code simpler and also it should also make the nuances of type
   matching more straightforward.

--- a/pg8000/converters.py
+++ b/pg8000/converters.py
@@ -257,7 +257,7 @@ def uuid_in(data):
 class PGInterval:
     UNIT_MAP = {
         "millennia": "millennia",
-        "millenium": "millennia",
+        "millennium": "millennia",
         "centuries": "centuries",
         "century": "centuries",
         "decades": "decades",

--- a/pg8000/dbapi.py
+++ b/pg8000/dbapi.py
@@ -114,7 +114,7 @@ BINARY = bytes
 
 
 def PgDate(year, month, day):
-    """Constuct an object holding a date value.
+    """Construct an object holding a date value.
 
     This function is part of the `DBAPI 2.0 specification
     <http://www.python.org/dev/peps/pep-0249/>`_.
@@ -159,7 +159,7 @@ def DateFromTicks(ticks):
 
 
 def TimeFromTicks(ticks):
-    """Construct an objet holding a time value from the given ticks value
+    """Construct an object holding a time value from the given ticks value
     (number of seconds since the epoch).
 
     This function is part of the `DBAPI 2.0 specification

--- a/test/dbapi/test_dbapi20.py
+++ b/test/dbapi/test_dbapi20.py
@@ -53,9 +53,9 @@ __author__ = "Stuart Bishop <zen@shangri-la.dropbear.id.au>"
 # - Now a subclass of TestCase, to avoid requiring the driver stub
 #   to use multiple inheritance
 # - Reversed the polarity of buggy test in test_description
-# - Test exception heirarchy correctly
+# - Test exception hierarchy correctly
 # - self.populate is now self._populate(), so if a driver stub
-#   overrides self.ddl1 this change propogates
+#   overrides self.ddl1 this change propagates
 # - VARCHAR columns now have a width, which will hopefully make the
 #   DDL even more portible (this will be reversed if it causes more problems)
 # - cursor.rowcount being checked after various execute and fetchXXX methods
@@ -159,7 +159,7 @@ def test_paramstyle():
 
 def test_Exceptions():
     # Make sure required exceptions exist, and are in the
-    # defined heirarchy.
+    # defined hierarchy.
     assert issubclass(driver.Warning, Exception)
     assert issubclass(driver.Error, Exception)
     assert issubclass(driver.InterfaceError, driver.Error)
@@ -376,7 +376,7 @@ def test_fetchone(cursor):
         cursor.fetchone()
 
     # cursor.fetchone should raise an Error if called after
-    # executing a query that cannnot return rows
+    # executing a query that cannot return rows
     executeDDL1(cursor)
     with pytest.raises(driver.Error):
         cursor.fetchone()
@@ -388,7 +388,7 @@ def test_fetchone(cursor):
     assert cursor.rowcount in (-1, 0)
 
     # cursor.fetchone should raise an Error if called after
-    # executing a query that cannnot return rows
+    # executing a query that cannot return rows
     cursor.execute("insert into %sbooze values ('Victoria Bitter')" % (table_prefix))
     with pytest.raises(driver.Error):
         cursor.fetchone()

--- a/test/legacy/test_dbapi20.py
+++ b/test/legacy/test_dbapi20.py
@@ -53,9 +53,9 @@ __author__ = "Stuart Bishop <zen@shangri-la.dropbear.id.au>"
 # - Now a subclass of TestCase, to avoid requiring the driver stub
 #   to use multiple inheritance
 # - Reversed the polarity of buggy test in test_description
-# - Test exception heirarchy correctly
+# - Test exception hierarchy correctly
 # - self.populate is now self._populate(), so if a driver stub
-#   overrides self.ddl1 this change propogates
+#   overrides self.ddl1 this change propagates
 # - VARCHAR columns now have a width, which will hopefully make the
 #   DDL even more portible (this will be reversed if it causes more problems)
 # - cursor.rowcount being checked after various execute and fetchXXX methods
@@ -159,7 +159,7 @@ def test_paramstyle():
 
 def test_Exceptions():
     # Make sure required exceptions exist, and are in the
-    # defined heirarchy.
+    # defined hierarchy.
     assert issubclass(driver.Warning, Exception)
     assert issubclass(driver.Error, Exception)
     assert issubclass(driver.InterfaceError, driver.Error)
@@ -390,7 +390,7 @@ def test_fetchone(cursor):
         cursor.fetchone()
 
     # cursor.fetchone should raise an Error if called after
-    # executing a query that cannnot return rows
+    # executing a query that cannot return rows
     executeDDL1(cursor)
     with pytest.raises(driver.Error):
         cursor.fetchone()
@@ -402,7 +402,7 @@ def test_fetchone(cursor):
     assert cursor.rowcount in (-1, 0)
 
     # cursor.fetchone should raise an Error if called after
-    # executing a query that cannnot return rows
+    # executing a query that cannot return rows
     cursor.execute("insert into %sbooze values ('Victoria Bitter')" % (table_prefix))
     with pytest.raises(driver.Error):
         cursor.fetchone()


### PR DESCRIPTION
Note that fixing the "millennium" typo may be a breaking change.

Please double-check whether this should be a typo-fix, or whether the correct spelling should be added as new key. I can update this (or remove that commit completely) as directed.