### PR TITLE
Fix copy tests for PostgreSQL 16

### DIFF
--- a/test/dbapi/test_copy.py
+++ b/test/dbapi/test_copy.py
@@ -82,7 +82,7 @@ def test_copy_from_with_error(db_table):
         ),
         "W": ('COPY t1, line 2, column f1: ""',),
         "F": ("numutils.c",),
-        "R": ("pg_atoi", "pg_strtoint32"),
+        "R": ("pg_atoi", "pg_strtoint32", "pg_strtoint32_safe"),
     }
     earg = e.value.args[0]
     for k, v in arg.items():

--- a/test/legacy/test_copy.py
+++ b/test/legacy/test_copy.py
@@ -83,7 +83,7 @@ def test_copy_from_with_error(db_table):
             ),
             "W": ('COPY t1, line 2, column f1: ""',),
             "F": ("numutils.c",),
-            "R": ("pg_atoi", "pg_strtoint32"),
+            "R": ("pg_atoi", "pg_strtoint32", "pg_strtoint32_safe"),
         }
         earg = e.value.args[0]
         for k, v in arg.items():

--- a/test/native/test_copy.py
+++ b/test/native/test_copy.py
@@ -95,7 +95,7 @@ def test_copy_from_with_error(db_table):
         ),
         "W": ('COPY t1, line 2, column f1: ""',),
         "F": ("numutils.c",),
-        "R": ("pg_atoi", "pg_strtoint32"),
+        "R": ("pg_atoi", "pg_strtoint32", "pg_strtoint32_safe"),
     }
     earg = e.value.args[0]
     for k, v in arg.items():


### PR DESCRIPTION
PostgreSQL 16 converted a few datatype input functions to use "soft" error reporting. This changed the function name and the tests checking for execptions in this function have to be adjusted.

This was changed in PostgreSQL in this commit: https://github.com/postgres/postgres/commit/ccff2d20ed9622815df2a7deffce8a7b14830965