### PR TITLE
Fix doctest for PostgreSQL 15+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -639,7 +639,7 @@ the server:
 >>>
 >>> con.run("SELECT :v IS NULL", v=None)
 Traceback (most recent call last):
-pg8000.exceptions.DatabaseError: {'S': 'ERROR', 'V': 'ERROR', 'C': '42P18', 'M': 'could not determine data type of parameter $1', 'F': 'postgres.c', 'L': '...', 'R': 'exec_parse_message'}
+pg8000.exceptions.DatabaseError: {'S': 'ERROR', 'V': 'ERROR', 'C': '42P18', 'M': 'could not determine data type of parameter $1', 'F': 'postgres.c', 'L': '...', 'R': '...'}
 >>>
 >>> con.close()
 


### PR DESCRIPTION
Since PostgreSQL 15 `pg_analyze_and_rewrite_varparams` is used for the common code to analyze the arguments of a query. Before the same code exists in multiple locations (in `exec_parse_message` and `PrepareQuery`).

This was changed in: https://github.com/postgres/postgres/commit/25751f54b8e02a8fff62e9dbdbc9f2efbb4e8dc1