### PR TITLE
Tests: fixup for the dbname mentioned in a couple of SCRAM-related test comments.

### DIFF
--- a/test/dbapi/auth/test_scram-sha-256.py
+++ b/test/dbapi/auth/test_scram-sha-256.py
@@ -3,7 +3,7 @@ import pytest
 from pg8000.dbapi import DatabaseError, connect
 
 # This requires a line in pg_hba.conf that requires scram-sha-256 for the
-# database pg8000_scram-sha-256
+# database pg8000_scram_sha_256
 
 DB = "pg8000_scram_sha_256"
 

--- a/test/legacy/auth/test_scram-sha-256_ssl.py
+++ b/test/legacy/auth/test_scram-sha-256_ssl.py
@@ -3,7 +3,7 @@ import pytest
 from pg8000 import DatabaseError, connect
 
 # This requires a line in pg_hba.conf that requires scram-sha-256 for the
-# database pg8000_scram-sha-256
+# database pg8000_scram_sha_256
 
 DB = "pg8000_scram_sha_256"
 


### PR DESCRIPTION
Spotted during review of the change(s) between v1.30.5 and v1.31.1 - nitpicky, but it seemed worth offering the fixup, having noticed it.