### PR TITLE
Allow setting arbitrary init parameters

### DIFF
--- a/src/pg8000/__init__.py
+++ b/src/pg8000/__init__.py
@@ -107,6 +107,7 @@ def connect(
     tcp_keepalive=True,
     application_name=None,
     replication=None,
+    init_params=None,
 ):
     return Connection(
         user,
@@ -121,6 +122,7 @@ def connect(
         tcp_keepalive=tcp_keepalive,
         application_name=application_name,
         replication=replication,
+        init_params=init_params,
     )
 
 

--- a/src/pg8000/core.py
+++ b/src/pg8000/core.py
@@ -271,6 +271,7 @@ class CoreConnection:
         tcp_keepalive=True,
         application_name=None,
         replication=None,
+        init_params=None,
         sock=None,
     ):
         self._client_encoding = "utf8"
@@ -295,6 +296,7 @@ class CoreConnection:
             "database": database,
             "application_name": application_name,
             "replication": replication,
+            **(init_params or {})
         }
 
         for k, v in tuple(init_params.items()):

--- a/src/pg8000/dbapi.py
+++ b/src/pg8000/dbapi.py
@@ -206,6 +206,7 @@ def connect(
     tcp_keepalive=True,
     application_name=None,
     replication=None,
+    init_params=None,
     sock=None,
 ):
     return Connection(
@@ -221,6 +222,7 @@ def connect(
         tcp_keepalive=tcp_keepalive,
         application_name=application_name,
         replication=replication,
+        init_params=init_params,
         sock=sock,
     )
 

--- a/src/pg8000/legacy.py
+++ b/src/pg8000/legacy.py
@@ -125,6 +125,7 @@ def connect(
     tcp_keepalive=True,
     application_name=None,
     replication=None,
+    init_params=None,
 ):
     return Connection(
         user,
@@ -139,6 +140,7 @@ def connect(
         tcp_keepalive=tcp_keepalive,
         application_name=application_name,
         replication=replication,
+        init_params=init_params,
     )
 
 


### PR DESCRIPTION
Introduce a new `init_params` option that allows setting startup parameters outside of the parameters that pg8000 has dedicated support for setting.