### PR TITLE
Accept "17rc1" as server version in tests

### DIFF
--- a/test/dbapi/conftest.py
+++ b/test/dbapi/conftest.py
@@ -1,6 +1,7 @@
 from os import environ
 
 import pytest
+import re
 
 import pg8000.dbapi
 
@@ -57,5 +58,5 @@ def pg_version(cursor):
     cursor.execute("select current_setting('server_version')")
     retval = cursor.fetchall()
     version = retval[0][0]
-    idx = version.index(".")
-    return int(version[:idx])
+    major = re.match(r'\d+', version).group() # leading digits in 17.0, 17rc1
+    return int(major)

--- a/test/native/conftest.py
+++ b/test/native/conftest.py
@@ -1,6 +1,7 @@
 from os import environ
 
 import pytest
+import re
 
 import pg8000.native
 
@@ -45,5 +46,5 @@ def con(request, db_kwargs):
 def pg_version(con):
     retval = con.run("select current_setting('server_version')")
     version = retval[0][0]
-    idx = version.index(".")
-    return int(version[:idx])
+    major = re.match(r'\d+', version).group() # leading digits in 17.0, 17rc1
+    return int(major)


### PR DESCRIPTION
The old coding assumed that PG server versions would always contain a dot, but that's not true while in beta or rc.