### PR TITLE
Another suggestion for PostgreSQL native parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1014,6 +1014,64 @@ these additional parameters can be specified using the `startup_params` paramete
 
 ```
 
+### PostgreSQL pure native parameter
+
+In this mode, pg8000 will not perform any local parsing of the SQL-string and
+only rely on the native PostgreSQL parameter handling.  The value of the
+parameters are passed as numeric dictionary keys.
+
+```python
+>>> import pg8000.native
+>>>
+>>> con = pg8000.native.Connection('postgres', password="cpsnow")
+>>>
+>>> con.run_native("SELECT $1", {1: 'A Time Of Hope'})
+[['A Time Of Hope']]
+>>>
+>>> con.close()
+
+```
+
+`run_native`, like `run`, supports a `types` parameter, but instead of string
+keys it uses integer keys, in a similar fashion as the parameters dict:
+
+```python
+>>> import pg8000.native
+>>>
+>>> con = pg8000.native.Connection("postgres", password="cpsnow")
+>>>
+>>> con.run_native("SELECT $1 IS NULL", {1: None}, types={1: pg8000.native.TIMESTAMP})
+[[True]]
+>>>
+>>> con.close()
+
+```
+
+Prepared statements can also be run in this mode, by setting the `native_params`
+flag:
+
+```python
+>>> import pg8000.native
+>>>
+>>> con = pg8000.native.Connection("postgres", password="cpsnow")
+>>>
+>>> # Create the prepared statement
+>>> ps = con.prepare("SELECT cast($1 as varchar)", native_params=True)
+>>>
+>>> # Execute the statement repeatedly
+>>> ps.run({1: "speedy"})
+[['speedy']]
+>>> ps.run({1: "rapid"})
+[['rapid']]
+>>> ps.run({1: "swift"})
+[['swift']]
+>>>
+>>> # Close the prepared statement, releasing resources on the server
+>>> ps.close()
+>>>
+>>> con.close()
+
+```
 
 ## DB-API 2 Interactive Examples
 

--- a/test/native/test_prepared_statement.py
+++ b/test/native/test_prepared_statement.py
@@ -5,3 +5,13 @@ def test_prepare(con):
 def test_run(con):
     ps = con.prepare("SELECT cast(:v as varchar)")
     ps.run(v="speedy")
+
+
+def test_prepare_native(con):
+    con.prepare("SELECT CAST($1 AS INTEGER)", native_params=True)
+
+
+def test_run_native(con):
+    ps = con.prepare("SELECT cast($1 as varchar)", native_params=True)
+    rows = ps.run({1: "speedy"})
+    assert rows[0] == ["speedy"]

--- a/test/native/test_query.py
+++ b/test/native/test_query.py
@@ -239,3 +239,8 @@ def test_max_parameters(con):
 def test_pg_placeholder_style(con):
     rows = con.run("SELECT $1", title="A Time Of Hope")
     assert rows[0] == ["A Time Of Hope"]
+
+
+def test_native_parameters(con):
+    rows = con.run_native("SELECT $1", {1: "A Time Of Hope"})
+    assert rows[0] == ["A Time Of Hope"]


### PR DESCRIPTION
Here's another suggestion for how to do PostgreSQL native parameters. It avoids unnecessary local parsing of the SQL string and provides a way of passing the values that mirrors the numbers in the string.