### PR TITLE
Minor fixes: README badge & duplicate dict entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ distributed under the BSD 3-clause license.
 All bug reports, feature requests and contributions are welcome at
 [http://github.com/tlocke/pg8000/](http://github.com/tlocke/pg8000/).
 
-[![Workflow Status Badge](https://github.com/tlocke/pg8000/workflows/pg8000/badge.svg)](https://github.com/tlocke/pg8000/actions)
+[![Workflow Status Badge](https://github.com/tlocke/pg8000/actions/workflows/pg8000/badge.svg)](https://github.com/tlocke/pg8000/actions/workflows/test.yml)
 
 ## Installation
 

--- a/src/pg8000/converters.py
+++ b/src/pg8000/converters.py
@@ -675,7 +675,6 @@ PG_TYPES = {
     TEXT_ARRAY: string_array_in,  # text[]
     TIME: time_in,  # time
     TIME_ARRAY: time_array_in,  # time[]
-    INTERVAL: interval_in,  # interval
     TIMESTAMP: timestamp_in,  # timestamp
     TIMESTAMP_ARRAY: timestamp_array_in,  # timestamp
     TIMESTAMPTZ: timestamptz_in,  # timestamptz


### PR DESCRIPTION
Fairly low effort change here, but I stumbled across two minor issues.  The workflow status badge is showing as "broken" in the README because of experimental branch changes while `main` is just fine, so this fixes the badge to reflect the `main` status.  And while evaluating `ruff`, it spotted that there's a duplicate entry in a types dictionary here.